### PR TITLE
修复nuxt+egg在开发环境下无法热更新

### DIFF
--- a/app/middleware/nuxtrender.js
+++ b/app/middleware/nuxtrender.js
@@ -2,27 +2,31 @@
 
 module.exports = function (options, app) {
   return async (ctx, next) => {
-    // webpack hot reload
-    //if (ctx.path !== '/__webpack_hmr') {
-      await next();
-      // ignore status if not 404
-      if (ctx.status !== 404 || ctx.method !== 'GET') {
-        return;
-      }
+    
+    await next();
+    // ignore status if not 404
+    if (ctx.status !== 404 || ctx.method !== 'GET') {
+      return;
+    }
 
-      ctx.status = 200;
-      const path = ctx.path;
-      if (/\.js$/.test(path)) {
-        ctx.set('Content-Type', 'application/javascript');
-      }
-      if (/\.css/.test(path)) {
-        ctx.set('Content-Type', 'text/css');
-      }
-      // the "nuxt.render" returns callback, not Promise
-      await new Promise(resolve => {
-        app.nuxt.render(ctx.req, ctx.res, resolve);
-      });
-      next();
-    //}
+    ctx.status = 200;
+    const path = ctx.path;
+    if (/\.js$/.test(path)) {
+      ctx.set('Content-Type', 'application/javascript');
+    }
+    if (/\.css/.test(path)) {
+      ctx.set('Content-Type', 'text/css');
+    }
+    // webpack hot reload
+    // egg will set 'content-length' with value, it will disable the hot middleware keep alive.
+    // egg 默认设置了 'content-length' 值，导致热更新失败，建议去掉该值保持活跃
+    if (ctx.path === '/__webpack_hmr') { 
+      ctx.response.remove('content-length')
+    }
+    // the "nuxt.render" returns callback, not Promise
+    await new Promise(resolve => {
+      app.nuxt.render(ctx.req, ctx.res, resolve);
+    });
+    next();
   }
 };


### PR DESCRIPTION
因egg自动给content-length赋值，长度为20，影响了socket-io的持续加载，去掉即可热更新。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
